### PR TITLE
Fixing issues: node dockerfile + git protocol

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # Version 1.0
 
 # Use Docker's nodejs, which is based on ubuntu
-FROM dockerfile/nodejs
+FROM node:latest
 MAINTAINER John E. Arnold, iohannes.eduardus.arnold@gmail.com
 
 # Get Etherpad-lite's other dependencies
@@ -15,7 +15,7 @@ RUN apt-get update
 RUN apt-get install -y gzip git-core curl python libssl-dev pkg-config build-essential supervisor
 
 # Grab the latest Git version
-RUN cd /opt && git clone git://github.com/ether/etherpad-lite.git etherpad
+RUN cd /opt && git clone https://github.com/ether/etherpad-lite.git etherpad
 
 # Install node dependencies
 RUN /opt/etherpad/bin/installDeps.sh


### PR DESCRIPTION
Repository dockerfile/nodejs has been deprecated.
Switching git clone protocol: git:// => https://