### PR TITLE
Put apt-get update & install in a single layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,18 @@ FROM node:latest
 MAINTAINER John E. Arnold, iohannes.eduardus.arnold@gmail.com
 
 # Get Etherpad-lite's other dependencies
-RUN apt-get update
-RUN apt-get install -y gzip git-core curl python libssl-dev pkg-config build-essential supervisor
+RUN apt-get update && apt-get install -y \
+  build-essential \
+  curl \
+  gzip \
+  git-core \
+  libssl-dev \
+  pkg-config \
+  python \
+  supervisor \
+  
+  && rm -rf /var/lib/apt/lists/*
+
 
 # Grab the latest Git version
 RUN cd /opt && git clone https://github.com/ether/etherpad-lite.git etherpad


### PR DESCRIPTION
As per [0], apt-get update & apt-get install should be in a single Docker layer.

```
Using apt-get update alone in a RUN statement causes caching issues
and subsequent apt-get install instructions fail
```

This exact problem hit me just now...


[0] https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#apt-get
